### PR TITLE
Adapt to new courses.

### DIFF
--- a/eguide.tex
+++ b/eguide.tex
@@ -19,9 +19,9 @@
 \supervisor{Professor John Doe}			% Name of the supervisor
 
 %%%%%%% Name of the department.  (Ignored if you are writing senior thesis.)
-\department{Communications and Computer Engineering}
-%\department{Intelligence Science and Technology}
-%\department{Social Informatics}
+\course{Communications and Computer Engineering}
+%\course{Intelligence Science and Technology}
+%\course{Social Informatics}
 
 %%%%%%% Date of submission
 \date{February 12th, 2019} 

--- a/guide.tex
+++ b/guide.tex
@@ -20,11 +20,11 @@
 \jauthor{末永 幸平}				% 和文著者名
 \eauthor{Kohei Suenaga}			% 英文著者名
 \supervisor{John Doe 教授}			% 指導教員名
-% 修士論文の場合は専攻名を選択．特別研究報告書の場合は単に無視される．
-\department{通信情報システム}
-%\department{知能情報学}
-%\department{社会情報学}
-\date{2019年2月12日}				% 提出年月日
+% 修士論文の場合はコース名を選択．特別研究報告書の場合は単に無視される．
+\course{通信情報システム}
+%\course{知能情報学}
+%\course{社会情報学}
+\date{2025年1月31日}				% 提出年月日
 
 
 \begin{document}

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -326,6 +326,7 @@
 \def\supervisor#1{\gdef\@supervisor{#1}}
 \def\date#1{\gdef\@date{#1}}
 \def\department#1{\gdef\@department{#1}}		% 2.10 (3)
+\def\course#1{\gdef\@department{#1}}		% 2.10 (3)
 
 \def\@jtitle{\mkt@warning\jtitle}
 \def\@etitle{\mkt@warning\etitle}
@@ -339,7 +340,7 @@
 \def\@author{\@eauthor}
 \def\mkt@masterthesis{Master's Thesis}
 \def\mkt@supervisor{Supervisor}
-\def\mkt@department{Department of \@department \\		% 2.10 (3)
+\def\mkt@department{Course of \@department \\ Department of Informatics \\		% 2.10 (3)
 	Graduate School of Informatics\\
 	Kyoto University}
 \else
@@ -347,7 +348,7 @@
 \def\@author{\@jauthor}
 \def\mkt@masterthesis{修士論文}
 \def\mkt@supervisor{指導教員}
-\def\mkt@department{京都大学大学院情報学研究科\\修士課程\@department 専攻}
+\def\mkt@department{京都大学大学院情報学研究科\\修士課程 情報学専攻 \@department コース}
 								% 2.10 (3)
 \fi
 


### PR DESCRIPTION
A new macro `\course` is provided.  The old macro `\department` is not removed (but should be deprecated).