### PR TITLE
Compiler support for LuaLaTeX

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,5 +1,6 @@
-$latex = 'uplatex';
-$bibtex = 'upbibtex';
-$dvipdf = 'dvipdfmx %O -o %D %S';
-$makeindex = 'mendex -U %O -o %D %S';
-$pdf_mode = 3; 
+#!/usr/bin/env perl
+$latex            = 'uplatex';
+$bibtex           = 'upbibtex';
+$dvipdf           = 'dvipdfmx %O -o %D %S';
+$makeindex        = 'mendex -U %O -o %D %S';
+$pdf_mode         = 3;

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,7 +1,5 @@
-# #!/usr/bin/env perl
-# $pdf_mode         = 3;
-# $latex            = 'platex -halt-on-error';
-# $latex_silent     = 'platex -halt-on-error -interaction=batchmode';
-# $bibtex           = 'pbibtex';
-# $dvipdf           = 'dvipdfmx %O -o %D %S';
-# $makeindex        = 'mendex %O -o %D %S';
+$latex = 'uplatex';
+$bibtex = 'upbibtex';
+$dvipdf = 'dvipdfmx %O -o %D %S';
+$makeindex = 'mendex -U %O -o %D %S';
+$pdf_mode = 3; 

--- a/eguide.tex
+++ b/eguide.tex
@@ -1,3 +1,8 @@
+% Load plautopatch for (u)pLaTeX
+\ifx\kanjiskip\undefined\else
+  \RequirePackage{plautopatch}
+\fi
+
 \documentclass[master,english]{kuisthesis}
 
 \def\LATEX{{\rm (L\kern-.36em\raise.3ex\hbox{\sc a})\TeX}}

--- a/guide.tex
+++ b/guide.tex
@@ -1,3 +1,8 @@
+% Load plautopatch for (u)pLaTeX
+\ifx\kanjiskip\undefined\else
+  \RequirePackage{plautopatch}
+\fi
+
 % \documentclass{kuisthesis}			% 特別研究報告書
 \documentclass[master]{kuisthesis}		% 修士論文(和文)
 %\documentclass[master,english]{kuisthesis}	% 修士論文(英文)

--- a/kuisthesis.cls
+++ b/kuisthesis.cls
@@ -1,11 +1,18 @@
-% kuisthesi.cls  1-Apr-96 by Hiroshi Nakashima (ver 2.00)
+% kuisthesis.cls  1-Apr-96 by Hiroshi Nakashima (ver 2.00)
+% ver 3.00 13-Dec-2025: Added LuaLaTeX support
 
-\ifx\pfmtname\undefined
-\NeedsTeXFormat{LaTeX2e}
+\ifx\directlua\undefined
+  % pLaTeX or upLaTeX or standard LaTeX
+  \ifx\pfmtname\undefined
+    \NeedsTeXFormat{LaTeX2e}
+  \else
+    \NeedsTeXFormat{pLaTeX2e}
+  \fi
 \else
-\NeedsTeXFormat{pLaTeX2e}
+  % LuaLaTeX
+  \NeedsTeXFormat{LaTeX2e}
 \fi
 
-\ProvidesClass{kuisthesis}[1996/04/01 ver 2.00]
+\ProvidesClass{kuisthesis}[2025/12/13 ver 3.00 with LuaLaTeX support]
 \input{kuisthesis.sty}
 \endinput

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -1,6 +1,7 @@
 % Copyright (C) 1996 by Dept. Information Science, Kyoto University
 % Copyright (C) 1999 by Computer Science Course,
 %	Scool of Informatics and Mathematical Science
+% kuisthesis.sty 13-Dec-25 by Kotaro Matsuoka   (ver 3.00)
 % kuisthesis.sty 26-Jan-00 by Hiroyuki Tarumi   (ver 2.11)
 % kuisthesis.sty 14-Dec-99 by Hiroyuki Tarumi   (ver 2.10)
 %
@@ -16,6 +17,14 @@
 % j-article.sty 10-Feb-89 from report.sty 16-Mar-88
 %
 % REVISION
+% ver 3.00 13-Dec-25 by Kotaro Matsuoka
+% (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
+%     luatexja package.
+% (2) Treat LuaLaTeX as ASCII-compatible for \ifASCII conditional.
+% (3) Add LuaLaTeX-specific handling for \jspaceskip and \@Kwidth using \zw.
+% (4) Add LuaLaTeX-specific font commands (\mc, \gt) using luatexja's
+%     \mcfamily and \gtfamily.
+%
 % ver 2.11 26-Jan-00 by Hiroyuki Tarumi
 %     Bug Fix: Contents was causing \clearpage, but it was a bug.
 %	\sectionNC is introduced to fix it.
@@ -62,6 +71,7 @@
 
 %%%%%% Engine Detection %%%%%%
 
+% 3.00(1)>>
 %% \ifLuaTeX is true if running under LuaLaTeX
 \newif\ifLuaTeX \LuaTeXfalse
 \ifx\directlua\undefined\else\LuaTeXtrue\fi
@@ -70,6 +80,7 @@
 \ifLuaTeX
   \RequirePackage{luatexja}
 \fi
+% 3.00(1)<<
 
 %%%%%% LaTeX Version %%%%%%
 
@@ -78,11 +89,13 @@
 
 % 2.00 (1)>>
 \newif\ifASCII \ASCIIfalse
+% 3.00(2)>>
 \ifLuaTeX
   \ASCIItrue  % Treat LuaLaTeX as ASCII-compatible (luatexja provides similar interface)
 \else
   \ifx\jintercharskip\undefined\ASCIItrue\fi
 \fi
+% 3.00(2)<<
 \newif\if@LaTeX@e \@LaTeX@efalse
 \newif\if@LaTeX@eN \@LaTeX@eNfalse
 \def\@tempa{LaTeX2e}
@@ -150,12 +163,14 @@
 
 \ifASCII
 
+% 3.00(3)>>
 \ifLuaTeX
   % LuaLaTeX: \zw is always available from luatexja
   % Define \jspaceskip as compatibility shim
   \newdimen\jspaceskip
   \jspaceskip=1\zw
 \else
+% 3.00(3)<<
   % ASCII pTeX: hook \@setsize to set \jspaceskip
   \let\latex@setsize\@setsize
   \def\@setsize#1#2#3#4{\latex@setsize{#1}{#2}{#3}{#4}\jspaceskip1zw}
@@ -178,12 +193,14 @@
 	is not supported in ASCII version}}
 
 \if@LaTeX@eN							% 2.00(3)>>
+% 3.00(4)>>
 \ifLuaTeX
   % LuaLaTeX: luatexja provides \mcfamily, \gtfamily
   % Use \relax for math mode (user can load luatexja-preset for math fonts)
   \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\relax}
   \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\relax}
 \else
+% 3.00(4)<<
   \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\mathmc}
   \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\mathgt}
 \fi
@@ -271,9 +288,11 @@
 %%%%%% Page Layout Parameters %%%%%%
 
 \newdimen\@Kwidth
+% 3.00(3)>>
 \ifLuaTeX
   \@Kwidth=1\zw  % LuaLaTeX: use \zw from luatexja
 \else
+% 3.00(3)<<
   \@Kwidth\jspaceskip  % pTeX: use \jspaceskip set by \@setsize hook
 \fi
 

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -60,6 +60,17 @@
 %     version, those counters are mistakingly reset when the counter
 %     `section' is stepped.
 
+%%%%%% Engine Detection %%%%%%
+
+%% \ifLuaTeX is true if running under LuaLaTeX
+\newif\ifLuaTeX \LuaTeXfalse
+\ifx\directlua\undefined\else\LuaTeXtrue\fi
+
+%% Auto-load luatexja for LuaLaTeX
+\ifLuaTeX
+  \RequirePackage{luatexja}
+\fi
+
 %%%%%% LaTeX Version %%%%%%
 
 %% \ifASCII is true if ASCII version Japanese TeX, which doesn't have
@@ -67,7 +78,11 @@
 
 % 2.00 (1)>>
 \newif\ifASCII \ASCIIfalse
-\ifx\jintercharskip\undefined\ASCIItrue\fi
+\ifLuaTeX
+  \ASCIItrue  % Treat LuaLaTeX as ASCII-compatible (luatexja provides similar interface)
+\else
+  \ifx\jintercharskip\undefined\ASCIItrue\fi
+\fi
 \newif\if@LaTeX@e \@LaTeX@efalse
 \newif\if@LaTeX@eN \@LaTeX@eNfalse
 \def\@tempa{LaTeX2e}
@@ -135,17 +150,23 @@
 
 \ifASCII
 
-% To use \jspaceskip
-\let\latex@setsize\@setsize
-\def\@setsize#1#2#3#4{\latex@setsize{#1}{#2}{#3}{#4}\jspaceskip1zw}
-
-% For compatibility to NTT jTeX
-\newcount\jfsize
-\let\setjglues\relax
-\let\jintercharskip\kanjiskip
-\let\jasciikanjiskip\xkanjiskip
-\let\jmathkanjiskip\xkanjiskip
-\newdimen\jspaceskip
+\ifLuaTeX
+  % LuaLaTeX: \zw is always available from luatexja
+  % Define \jspaceskip as compatibility shim
+  \newdimen\jspaceskip
+  \jspaceskip=1\zw
+\else
+  % ASCII pTeX: hook \@setsize to set \jspaceskip
+  \let\latex@setsize\@setsize
+  \def\@setsize#1#2#3#4{\latex@setsize{#1}{#2}{#3}{#4}\jspaceskip1zw}
+  % For compatibility to NTT jTeX
+  \newcount\jfsize
+  \let\setjglues\relax
+  \let\jintercharskip\kanjiskip
+  \let\jasciikanjiskip\xkanjiskip
+  \let\jmathkanjiskip\xkanjiskip
+  \newdimen\jspaceskip
+\fi
 
 % Following NTT primitives are not simulated.
 \def\defjintercharskip#1#2#3#4{\@asciiwarning{\defjintercharskip}}
@@ -157,8 +178,15 @@
 	is not supported in ASCII version}}
 
 \if@LaTeX@eN							% 2.00(3)>>
-\DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\mathmc}
-\DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\mathgt}
+\ifLuaTeX
+  % LuaLaTeX: luatexja provides \mcfamily, \gtfamily
+  % Use \relax for math mode (user can load luatexja-preset for math fonts)
+  \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\relax}
+  \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\relax}
+\else
+  \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\mathmc}
+  \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\mathgt}
+\fi
 \fi
 
 \def\dg{\gt}
@@ -242,7 +270,12 @@
 
 %%%%%% Page Layout Parameters %%%%%%
 
-\newdimen\@Kwidth \@Kwidth\jspaceskip
+\newdimen\@Kwidth
+\ifLuaTeX
+  \@Kwidth=1\zw  % LuaLaTeX: use \zw from luatexja
+\else
+  \@Kwidth\jspaceskip  % pTeX: use \jspaceskip set by \@setsize hook
+\fi
 
 \headheight1pc
 \headsep2pc


### PR DESCRIPTION
Dear Professors, 

Although #1 requests `pdflatex` support, the presence of a Japanese abstract makes this unfeasible. (By the way, the cause of that error is the use of the (u)pLaTeX-specific `zw` unit for Japanese whitespace; switching to `em` will resolve it.)

Instead, this PR adds support for `lualatex`, a newer LaTeX engine that supports Japanese. I have also added a .latexmkrc file to demonstrate an Overleaf-compatible configuration, as well as plautopatch to automatically fix incompatible packages during (u)pLaTeX compilation.