### PR TITLE
Add pdflatex support (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # kuisthesis-template
 
-## Known issues
+## Supported Engines
 
-- This style file currently cannot be used with `pdflatex`.  Instead, use `platex`, `pbibtex`, and `dvipdfmx`.
+- upLaTeX (with dvipdfmx)
+- LuaLaTeX
+- pdfLaTeX
+
+### Note for pdfLaTeX users
+
+Use `~` (tilde) between Japanese and English text to insert proper spacing:
+```latex
+日本語~\LaTeX~を使う
+```
+For upLaTeX and LuaLaTeX, tildes work as usual (non-breaking space), since spacing is inserted automatically.

--- a/eguide.tex
+++ b/eguide.tex
@@ -61,6 +61,8 @@ of informatics must obey rules given by each department.
 \end{eabstract}
 
 \begin{jabstract}				% Abstract in Japanese
+% NOTE: Tildes (~) between Japanese and English text are required for pdfLaTeX
+% to insert proper spacing. upLaTeX and LuaLaTeX insert spacing automatically.
 この手引は，京都大学工学部情報学科計算機科学コースにおける特別研究報告
 書の構成と形式について説明したものである．また，当コースで定めた形式に
 則った論文を日本語~\LaTeX~を用いて作成するためのスタイル・ファイル，

--- a/eguide.tex
+++ b/eguide.tex
@@ -62,7 +62,8 @@ of informatics must obey rules given by each department.
 
 \begin{jabstract}				% Abstract in Japanese
 % NOTE: Tildes (~) between Japanese and English text are required for pdfLaTeX
-% to insert proper spacing. upLaTeX and LuaLaTeX insert spacing automatically.
+% to insert proper spacing. For upLaTeX and LuaLaTeX, tildes work as usual
+% (non-breaking space to prevent line breaks), since spacing is automatic.
 この手引は，京都大学工学部情報学科計算機科学コースにおける特別研究報告
 書の構成と形式について説明したものである．また，当コースで定めた形式に
 則った論文を日本語~\LaTeX~を用いて作成するためのスタイル・ファイル，

--- a/eguide.tex
+++ b/eguide.tex
@@ -63,10 +63,10 @@ of informatics must obey rules given by each department.
 \begin{jabstract}				% Abstract in Japanese
 この手引は，京都大学工学部情報学科計算機科学コースにおける特別研究報告
 書の構成と形式について説明したものである．また，当コースで定めた形式に
-則った論文を日本語\LaTeX を用いて作成するためのスタイル・ファイル，
-\verb|kuisthesis|の使い方についても説明している．なお，この手引自体も
-\verb|kuisthesis|を用い，定められた形式に従って作成されているので，必
-要に応じてソース・ファイル\verb|guide.tex|を参照されたい．なお，情報学
+則った論文を日本語~\LaTeX~を用いて作成するためのスタイル・ファイル，
+\verb|kuisthesis|~の使い方についても説明している．なお，この手引自体も
+\verb|kuisthesis|~を用い，定められた形式に従って作成されているので，必
+要に応じてソース・ファイル~\verb|guide.tex|~を参照されたい．なお，情報学
 研究科の修士課程学生でこのマクロを利用する者は、各専攻の執筆規定に従う
 こと．
 \end{jabstract}

--- a/kuisthesis.cls
+++ b/kuisthesis.cls
@@ -1,5 +1,6 @@
 % kuisthesis.cls  1-Apr-96 by Hiroshi Nakashima (ver 2.00)
-% ver 3.00 13-Dec-2025: Added LuaLaTeX support
+% ver 3.01  1-Jan-2026: Added pdfLaTeX support by Kotaro Matsuoka
+% ver 3.00 13-Dec-2025: Added LuaLaTeX support by Kotaro Matsuoka
 
 \ifx\directlua\undefined
   % pLaTeX or upLaTeX or standard LaTeX
@@ -13,6 +14,6 @@
   \NeedsTeXFormat{LaTeX2e}
 \fi
 
-\ProvidesClass{kuisthesis}[2025/12/13 ver 3.00 with LuaLaTeX support]
+\ProvidesClass{kuisthesis}[2026/01/01 ver 3.01 with LuaLaTeX support]
 \input{kuisthesis.sty}
 \endinput

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -1,6 +1,7 @@
 % Copyright (C) 1996 by Dept. Information Science, Kyoto University
 % Copyright (C) 1999 by Computer Science Course,
 %	Scool of Informatics and Mathematical Science
+% kuisthesis.sty  1-Jan-26 by Kotaro Matsuoka   (ver 3.01)
 % kuisthesis.sty 13-Dec-25 by Kotaro Matsuoka   (ver 3.00)
 % kuisthesis.sty 26-Jan-00 by Hiroyuki Tarumi   (ver 2.11)
 % kuisthesis.sty 14-Dec-99 by Hiroyuki Tarumi   (ver 2.10)
@@ -17,6 +18,18 @@
 % j-article.sty 10-Feb-89 from report.sty 16-Mar-88
 %
 % REVISION
+% ver 3.01  1-Jan-26 by Kotaro Matsuoka
+% (1) Add pdfLaTeX support: engine detection (\ifpdfLaTeX) for pdfLaTeX
+%     without Japanese TeX primitives.
+% (2) Define \zw fallback (1em) for pdfLaTeX, enabling layout calculations
+%     that depend on Japanese character width. Also auto-load CJKutf8 package.
+% (3) Add pdfLaTeX-specific handling for \jspaceskip and dummy skip registers
+%     (\jintercharskip, \jasciikanjiskip, \jmathkanjiskip).
+% (4) Add pdfLaTeX-specific font commands (\mc, \gt) mapping to \rmfamily
+%     and \sffamily as fallbacks for mincho/gothic.
+% (5) Automatically wrap jabstract environment in CJK for pdfLaTeX, enabling
+%     Japanese abstract without manual CJK wrapping in document.
+%
 % ver 3.00 13-Dec-25 by Kotaro Matsuoka
 % (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
 %     luatexja package.
@@ -81,6 +94,37 @@
   \RequirePackage{luatexja}
 \fi
 % 3.00(1)<<
+
+% 3.01(1)>>
+%% pdfLaTeX fallback support
+%% \ifpdfLaTeX is true if running under pdfLaTeX (not LuaLaTeX, not pTeX)
+\newif\ifpdfLaTeX \pdfLaTeXfalse
+\ifLuaTeX\else
+  \ifx\kanjiskip\undefined
+    % No \kanjiskip means not pTeX/upTeX
+    \ifx\pdfoutput\undefined\else
+      \pdfLaTeXtrue
+    \fi
+    % Also check for modern LaTeX where \pdfoutput may not be defined but pdf mode is used
+    \ifx\pdfoutput\undefined
+      \ifx\outputmode\undefined\else
+        \pdfLaTeXtrue
+      \fi
+    \fi
+  \fi
+\fi
+% 3.01(1)<<
+
+% 3.01(2)>>
+%% Define \zw (zenkaku width) fallback for pdfLaTeX
+%% In Japanese TeX, 1zw = width of one full-width character ≈ 1em
+%% Also load CJKutf8 package for Japanese text support
+\ifpdfLaTeX
+  \newdimen\zw
+  \zw=1em
+  \RequirePackage{CJKutf8}
+\fi
+% 3.01(2)<<
 
 %%%%%% LaTeX Version %%%%%%
 
@@ -170,6 +214,19 @@
   \newdimen\jspaceskip
   \jspaceskip=1\zw
 \else
+% 3.01(3)>>
+\ifpdfLaTeX
+  % pdfLaTeX fallback: use our \zw definition (1em)
+  \newdimen\jspaceskip
+  \jspaceskip=1\zw
+  \newcount\jfsize
+  \let\setjglues\relax
+  % Define dummy skips for compatibility (not used in pdfLaTeX)
+  \newskip\jintercharskip
+  \newskip\jasciikanjiskip
+  \newskip\jmathkanjiskip
+\else
+% 3.01(3)<<
 % 3.00(3)<<
   % ASCII pTeX: hook \@setsize to set \jspaceskip
   \let\latex@setsize\@setsize
@@ -181,7 +238,7 @@
   \let\jasciikanjiskip\xkanjiskip
   \let\jmathkanjiskip\xkanjiskip
   \newdimen\jspaceskip
-\fi
+\fi\fi
 
 % Following NTT primitives are not simulated.
 \def\defjintercharskip#1#2#3#4{\@asciiwarning{\defjintercharskip}}
@@ -200,10 +257,17 @@
   \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\relax}
   \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\relax}
 \else
+% 3.01(4)>>
+\ifpdfLaTeX
+  % pdfLaTeX fallback: use roman/sans-serif as substitutes for mincho/gothic
+  \DeclareOldFontCommand{\mc}{\normalfont\rmfamily}{\mathrm}
+  \DeclareOldFontCommand{\gt}{\normalfont\sffamily}{\mathsf}
+\else
+% 3.01(4)<<
 % 3.00(4)<<
   \DeclareOldFontCommand{\mc}{\normalfont\mcfamily}{\mathmc}
   \DeclareOldFontCommand{\gt}{\normalfont\gtfamily}{\mathgt}
-\fi
+\fi\fi
 \fi
 
 \def\dg{\gt}
@@ -309,7 +373,7 @@
 \topmargin296mm \advance\topmargin-\textheight \divide\topmargin\tw@
 \advance\topmargin-\headheight \advance\topmargin-\headsep
 \advance\topmargin-1in
-\ifASCII\if@LaTeX@e\@@topmargin\topmargin\fi\fi			% 2.00(7)
+\ifASCII\ifpdfLaTeX\else\if@LaTeX@e\@@topmargin\topmargin\fi\fi\fi	% 2.00(7), 3.01: skip for pdfLaTeX
 
 \footskip 1.5\baselineskip
 
@@ -435,13 +499,27 @@
 	\@date
 	\end{center}\newpage}
 
-\def\jabstract{\@abstract\@jtitleforabst\@jauthor{内容梗概}
+% 3.01(5)>>
+% pdfLaTeX: wrap Japanese abstract in CJK environment automatically
+% CJK environment must wrap the entire abstract including title and author
+\ifpdfLaTeX
+  \def\kuis@jabstract@heading{内容梗概}
+  \def\jabstract{\begin{CJK}{UTF8}{min}%
+	\@abstract\@jtitleforabst\@jauthor{\kuis@jabstract@heading}
 	\ifASCII\else\tolerance2000\hbadness2000\fi
 	\parindent\@Kwidth\indent\ignorespaces}
+  \def\endjabstract{\end{CJK}\newpage}
+\else
+  \def\kuis@jabstract@heading{内容梗概}
+  \def\jabstract{\@abstract\@jtitleforabst\@jauthor{\kuis@jabstract@heading}
+	\ifASCII\else\tolerance2000\hbadness2000\fi
+	\parindent\@Kwidth\indent\ignorespaces}
+  \let\endjabstract\newpage
+\fi
+% 3.01(5)<<
 \def\eabstract{\@abstract\@etitleforabst\@eauthor{Abstract}\parindent1.5em
 	\noindent\ignorespaces}
 \let\endabstract\newpage
-\let\endjabstract\endabstract
 \let\endeabstract\endabstract
 
 % for compatibility

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -22,15 +22,19 @@
 % (1) Add pdfLaTeX support: engine detection (\ifpdfLaTeX) for pdfLaTeX
 %     without Japanese TeX primitives.
 % (2) Define \zw fallback (1em) for pdfLaTeX, enabling layout calculations
-%     that depend on Japanese character width. Also auto-load CJKutf8 package.
+%     that depend on Japanese character width. Auto-load bxcjkjatype package
+%     with ipaex-type1 and scale=0.95 for proper Japanese font size matching.
 % (3) Add pdfLaTeX-specific handling for \jspaceskip and dummy skip registers
 %     (\jintercharskip, \jasciikanjiskip, \jmathkanjiskip).
 % (4) Add pdfLaTeX-specific font commands (\mc, \gt) mapping to \rmfamily
 %     and \sffamily as fallbacks for mincho/gothic.
 % (5) Automatically wrap jabstract environment in CJK for pdfLaTeX, enabling
-%     Japanese abstract without manual CJK wrapping in document.
-% (6) Use IPAex Mincho (ipxm) font for better Japanese text quality.
-% NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese
+%     Japanese abstract without manual CJK wrapping in document. Use IPAex
+%     Gothic (ipxg) for title and heading, IPAex Mincho (ipxm) for body text.
+%     Fix first paragraph indent using CJK-based measurement.
+% (6) Add pdfLaTeX-specific list indents using em-based values instead of
+%     \@Kwidth to fix itemize/enumerate environment indentation.
+% NOTE: pdfLaTeX with CJK does not auto-insert space between Japanese
 %       and English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
 %       For upLaTeX/LuaLaTeX, tildes work as usual (non-breaking space).
 %
@@ -764,6 +768,22 @@
 \def\@listvi{\leftmargin\leftmarginvi \lst@listi}
 
 \@listi
+
+% 3.01(6)>>
+\ifpdfLaTeX
+  % pdfLaTeX: avoid \@Kwidth-based list indents; use em-based fallbacks.
+  \leftmargini2em
+  \leftmarginii2em
+  \leftmarginiii2em
+  \leftmarginiv2em
+  \leftmarginv2em
+  \leftmarginvi2em
+  \def\lst@listi{\labelsep.75em \labelwidth.25em
+	\rightmargin\z@ \listparindent\z@ \itemindent\z@
+	\partopsep\z@ \parsep\z@ \topsep\z@ \itemsep\z@}
+  \@listi
+\fi
+% 3.01(6)<<
 
 \def\labelenumi{\theenumi.} 
 \def\theenumi{\arabic{enumi}} 

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -32,7 +32,7 @@
 % (6) Use IPAex Mincho (ipxm) font for better Japanese text quality.
 % NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese
 %       and English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
-%       upLaTeX and LuaLaTeX insert spacing automatically, so tildes are optional.
+%       For upLaTeX/LuaLaTeX, tildes work as usual (non-breaking space).
 %
 % ver 3.00 13-Dec-25 by Kotaro Matsuoka
 % (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
@@ -509,7 +509,7 @@
 % Use IPAex Mincho (ipxm) for better font quality than default wadalab (min)
 % NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese and
 %       English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
-%       upLaTeX and LuaLaTeX insert spacing automatically, so tildes are optional.
+%       For upLaTeX/LuaLaTeX, tildes work as usual (non-breaking space).
 \ifpdfLaTeX
   \def\kuis@jabstract@heading{内容梗概}
   \def\jabstract{\begin{CJK}{UTF8}{ipxm}\CJKtilde

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -30,8 +30,9 @@
 % (5) Automatically wrap jabstract environment in CJK for pdfLaTeX, enabling
 %     Japanese abstract without manual CJK wrapping in document.
 % (6) Use IPAex Mincho (ipxm) font for better Japanese text quality.
-% NOTE: CJKutf8 does not auto-insert space between Japanese and English.
-%       Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
+% NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese
+%       and English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
+%       upLaTeX and LuaLaTeX insert spacing automatically, so tildes are optional.
 %
 % ver 3.00 13-Dec-25 by Kotaro Matsuoka
 % (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
@@ -506,8 +507,9 @@
 % pdfLaTeX: wrap Japanese abstract in CJK environment automatically
 % CJK environment must wrap the entire abstract including title and author
 % Use IPAex Mincho (ipxm) for better font quality than default wadalab (min)
-% NOTE: CJKutf8 does not auto-insert space between Japanese and English text.
-%       Use ~ (tilde) to insert proper spacing, e.g., 日本語~\LaTeX~を使う
+% NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese and
+%       English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
+%       upLaTeX and LuaLaTeX insert spacing automatically, so tildes are optional.
 \ifpdfLaTeX
   \def\kuis@jabstract@heading{内容梗概}
   \def\jabstract{\begin{CJK}{UTF8}{ipxm}\CJKtilde

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -122,11 +122,11 @@
 % 3.01(2)>>
 %% Define \zw (zenkaku width) fallback for pdfLaTeX
 %% In Japanese TeX, 1zw = width of one full-width character ≈ 1em
-%% Also load CJKutf8 package for Japanese text support
+%% Also load bxcjkjatype package for Japanese text support with proper scaling
 \ifpdfLaTeX
   \newdimen\zw
   \zw=1em
-  \RequirePackage{CJKutf8}
+  \RequirePackage[ipaex-type1,scale=0.95]{bxcjkjatype}
 \fi
 % 3.01(2)<<
 
@@ -506,16 +506,20 @@
 % 3.01(5)>>
 % pdfLaTeX: wrap Japanese abstract in CJK environment automatically
 % CJK environment must wrap the entire abstract including title and author
-% Use IPAex Mincho (ipxm) for better font quality than default wadalab (min)
-% NOTE: pdfLaTeX with CJKutf8 does not auto-insert space between Japanese and
+% Using bxcjkjatype with ipaex-type1 and scale option for proper font size
+% NOTE: pdfLaTeX with CJK does not auto-insert space between Japanese and
 %       English. Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
 %       For upLaTeX/LuaLaTeX, tildes work as usual (non-breaking space).
 \ifpdfLaTeX
-  \def\kuis@jabstract@heading{内容梗概}
+  \newbox\kuis@cjkindent
+  \def\kuis@CJKoneindent{%
+	\setbox\kuis@cjkindent\hbox{あ}%
+	\parindent\wd\kuis@cjkindent}
+  \def\kuis@jabstract@heading{{\CJKfamily{ipxg}内容梗概}}
   \def\jabstract{\begin{CJK}{UTF8}{ipxm}\CJKtilde
-	\@abstract\@jtitleforabst\@jauthor{\kuis@jabstract@heading}
+	\@abstract{\CJKfamily{ipxg}\@jtitleforabst}\@jauthor{\kuis@jabstract@heading}
 	\ifASCII\else\tolerance2000\hbadness2000\fi
-	\parindent\@Kwidth\indent\ignorespaces}
+	\kuis@CJKoneindent\par\noindent\hspace*{\parindent}\ignorespaces}
   \def\endjabstract{\end{CJK}\newpage}
 \else
   \def\kuis@jabstract@heading{内容梗概}

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -510,7 +510,7 @@
 %       Use ~ (tilde) to insert proper spacing, e.g., 日本語~\LaTeX~を使う
 \ifpdfLaTeX
   \def\kuis@jabstract@heading{内容梗概}
-  \def\jabstract{\begin{CJK}{UTF8}{ipxm}%
+  \def\jabstract{\begin{CJK}{UTF8}{ipxm}\CJKtilde
 	\@abstract\@jtitleforabst\@jauthor{\kuis@jabstract@heading}
 	\ifASCII\else\tolerance2000\hbadness2000\fi
 	\parindent\@Kwidth\indent\ignorespaces}

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -29,6 +29,7 @@
 %     and \sffamily as fallbacks for mincho/gothic.
 % (5) Automatically wrap jabstract environment in CJK for pdfLaTeX, enabling
 %     Japanese abstract without manual CJK wrapping in document.
+% (6) Use IPAex Mincho (ipxm) font for better Japanese text quality.
 %
 % ver 3.00 13-Dec-25 by Kotaro Matsuoka
 % (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
@@ -502,9 +503,10 @@
 % 3.01(5)>>
 % pdfLaTeX: wrap Japanese abstract in CJK environment automatically
 % CJK environment must wrap the entire abstract including title and author
+% Use IPAex Mincho (ipxm) for better font quality than default wadalab (min)
 \ifpdfLaTeX
   \def\kuis@jabstract@heading{内容梗概}
-  \def\jabstract{\begin{CJK}{UTF8}{min}%
+  \def\jabstract{\begin{CJK}{UTF8}{ipxm}%
 	\@abstract\@jtitleforabst\@jauthor{\kuis@jabstract@heading}
 	\ifASCII\else\tolerance2000\hbadness2000\fi
 	\parindent\@Kwidth\indent\ignorespaces}

--- a/kuisthesis.sty
+++ b/kuisthesis.sty
@@ -30,6 +30,8 @@
 % (5) Automatically wrap jabstract environment in CJK for pdfLaTeX, enabling
 %     Japanese abstract without manual CJK wrapping in document.
 % (6) Use IPAex Mincho (ipxm) font for better Japanese text quality.
+% NOTE: CJKutf8 does not auto-insert space between Japanese and English.
+%       Use ~ (tilde) for proper spacing, e.g., 日本語~\LaTeX~を使う
 %
 % ver 3.00 13-Dec-25 by Kotaro Matsuoka
 % (1) Add LuaLaTeX support: engine detection (\ifLuaTeX) and auto-loading
@@ -504,6 +506,8 @@
 % pdfLaTeX: wrap Japanese abstract in CJK environment automatically
 % CJK environment must wrap the entire abstract including title and author
 % Use IPAex Mincho (ipxm) for better font quality than default wadalab (min)
+% NOTE: CJKutf8 does not auto-insert space between Japanese and English text.
+%       Use ~ (tilde) to insert proper spacing, e.g., 日本語~\LaTeX~を使う
 \ifpdfLaTeX
   \def\kuis@jabstract@heading{内容梗概}
   \def\jabstract{\begin{CJK}{UTF8}{ipxm}%


### PR DESCRIPTION
This PR fixes #1, adds pdfLaTeX support to kuisthesis, enabling compilation with pdfLaTeX in addition to the existing upLaTeX and LuaLaTeX support. 
Although I thought adding `pdflatex` support was difficult when I wrote #6. However, I noticed that Japanese use is fairly limited, so we can use CJKutf8 to typeset Japanese for this limited use case.

  Summary

  - Add pdfLaTeX engine detection and fallback definitions
  - Automatically load CJKutf8 and wrap jabstract environment in CJK
  - Use IPAex Mincho (ipxm) font for high-quality Japanese text

  Changes

  Engine Detection

  - Add \ifpdfLaTeX conditional to detect pdfLaTeX (not LuaLaTeX, not pTeX/upTeX)

  Layout Support

  - Define \zw fallback (1em) for pdfLaTeX, enabling layout calculations that depend on Japanese character width
  - Add dummy skip registers (\jintercharskip, \jasciikanjiskip, \jmathkanjiskip) for compatibility

  Font Support

  - Auto-load CJKutf8 package for pdfLaTeX
  - Use IPAex Mincho (ipxm) instead of default wadalab (min) for better font quality
  - Map \mc → \rmfamily, \gt → \sffamily as fallbacks

  Japanese Abstract

  - Automatically wrap jabstract environment in \begin{CJK}{UTF8}{ipxm}...\end{CJK}
  - Enable \CJKtilde for proper spacing with ~ between Japanese and English text

  Usage Note

  For pdfLaTeX, use ~ (tilde) between Japanese and English text to insert proper spacing:
  日本語~\LaTeX~を使う
  For upLaTeX and LuaLaTeX, tildes work as usual (non-breaking space), since spacing is inserted automatically.